### PR TITLE
Pattern match scenario as a third arg

### DIFF
--- a/lib/behave.ex
+++ b/lib/behave.ex
@@ -26,8 +26,8 @@ defmodule Behave do
 
   defmacro scenario(title, do: block) do
     quote do
-      test unquote(title) do
-        var!(scenario) = Behave.Scenario.new()
+      test unquote(title), args do
+        var!(scenario) = Behave.Scenario.new(args)
         unquote(block)
         Behave.Scenario.run(var!(scenario))
       end

--- a/lib/scenario.ex
+++ b/lib/scenario.ex
@@ -10,24 +10,14 @@ defmodule Behave.Scenario do
   @type t :: %__MODULE__{}
 
   @spec new :: t
-  def new, do: %__MODULE__{}
+  def new(data \\ %{}), do: %__MODULE__{data: data}
 
-  defmacro given(name, do: block) do
-    name = Behave.string_to_function_name("given_#{name}")
-
-    quote do
-      def unquote(name)(scenario, _) do
-        result = unquote(block)
-        Behave.Scenario.__given__(scenario, result)
-      end
-    end
-  end
-
-  defmacro given(name, args, do: block) do
+  defmacro given(name, args \\ Macro.escape([]), assign \\ Macro.escape(%{}), do: block) do
     name = Behave.string_to_function_name("given_#{name}")
 
     quote do
       def unquote(name)(scenario, unquote(args)) do
+        unquote(assign) = scenario
         result = unquote(block)
         Behave.Scenario.__given__(scenario, result)
       end
@@ -50,26 +40,12 @@ defmodule Behave.Scenario do
     raise "Given needs to return a {:key, value} tuple or :ignore for executing side effects."
   end
 
-  defmacro act(name, do: block) do
-    name = Behave.string_to_function_name("act_#{name}")
-
-    quote do
-      def unquote(name)(scenario, _) do
-        var!(data) = scenario.data
-        _ = var!(data)
-        result = unquote(block)
-        Behave.Scenario.__act__(scenario, result)
-      end
-    end
-  end
-
-  defmacro act(name, args, do: block) do
+  defmacro act(name, args \\ Macro.escape([]), assign \\ Macro.escape(%{}), do: block) do
     name = Behave.string_to_function_name("act_#{name}")
 
     quote do
       def unquote(name)(scenario, unquote(args)) do
-        var!(data) = scenario.data
-        _ = var!(data)
+        unquote(assign) = scenario
         result = unquote(block)
         Behave.Scenario.__act__(scenario, result)
       end

--- a/lib/scenario.ex
+++ b/lib/scenario.ex
@@ -93,30 +93,12 @@ defmodule Behave.Scenario do
     raise "Act needs to return a {:key, value} tuple or :ignore for executing side effects."
   end
 
-  defmacro check(name, do: block) do
-    name = Behave.string_to_function_name("check_#{name}")
-
-    quote do
-      def unquote(name)(scenario, _) do
-        var!(data) = scenario.data
-        var!(results) = scenario.results
-        _ = var!(data)
-        _ = var!(results)
-        unquote(block)
-        scenario
-      end
-    end
-  end
-
-  defmacro check(name, args, do: block) do
+  defmacro check(name, args \\ Macro.escape([]), assign \\ Macro.escape(%{}), do: block) do
     name = Behave.string_to_function_name("check_#{name}")
 
     quote do
       def unquote(name)(scenario, unquote(args)) do
-        var!(data) = scenario.data
-        var!(results) = scenario.results
-        _ = var!(data)
-        _ = var!(results)
+        unquote(assign) = scenario
         unquote(block)
         scenario
       end

--- a/test/behave_dsl_test.exs
+++ b/test/behave_dsl_test.exs
@@ -2,6 +2,10 @@ defmodule BehaveDslTest do
   use Behave, steps: [TestSteps]
   use ExUnit.Case
 
+  setup do
+    [name: "dsl_coffee_machine"]
+  end
+
   scenario "make coffee with dsl" do
     given "coffee machine"
     given "it has water", amount: 250

--- a/test/behave_explicit_test.exs
+++ b/test/behave_explicit_test.exs
@@ -5,8 +5,12 @@ defmodule BehaveExplicitTest do
 
   import TestSteps
 
-  test "make coffee explicitly" do
-    Scenario.new()
+  setup do
+    [name: "dsl_coffee_machine"]
+  end
+
+  test "make coffee explicitly", args do
+    Scenario.new(args)
     |> Behave.__given__(&given_coffee_machine/2)
     |> Behave.__given__(&given_it_has_water/2, amount: 259)
     |> Behave.__given__(&given_it_has_coffee/2, cultivar: :crappy_robusta)

--- a/test/support/coffee_machine.ex
+++ b/test/support/coffee_machine.ex
@@ -3,10 +3,10 @@ defmodule CoffeeMachine do
   A simulation of a coffee machine.
   The coffee machine is modeled as a finite state machine, just to have some code to run simulated tests against.
   """
-  defstruct coffee: nil, water_ml: 0
+  defstruct name: nil, coffee: nil, water_ml: 0
 
-  @spec new :: %CoffeeMachine{coffee: nil, water_ml: 0}
-  def new, do: %__MODULE__{}
+  @spec new(String.t()) :: %CoffeeMachine{}
+  def new(name), do: %__MODULE__{name: name}
 
   @spec add_water(%CoffeeMachine{}, number) :: %CoffeeMachine{}
   def add_water(machine = %__MODULE__{}, amount) when is_number(amount) do

--- a/test/support/test_steps.ex
+++ b/test/support/test_steps.ex
@@ -1,9 +1,10 @@
 defmodule TestSteps do
+  use ExUnit.Case
   use Behave.Scenario
   import ExUnit.Assertions
 
-  given "coffee machine" do
-    {:coffee_machine, CoffeeMachine.new()}
+  given "coffee machine", [], %Behave.Scenario{data: %{name: name}} do
+    {:coffee_machine, CoffeeMachine.new(name)}
   end
 
   given "it has water", amount: amount do
@@ -14,7 +15,7 @@ defmodule TestSteps do
     {:coffee_machine, &CoffeeMachine.add_coffee(&1, cultivar)}
   end
 
-  act "i press the button" do
+  act "i press the button", [], %Behave.Scenario{data: data} do
     {:coffee, CoffeeMachine.brew(data.coffee_machine)}
   end
 

--- a/test/support/test_steps.ex
+++ b/test/support/test_steps.ex
@@ -18,7 +18,7 @@ defmodule TestSteps do
     {:coffee, CoffeeMachine.brew(data.coffee_machine)}
   end
 
-  check "it makes coffee" do
+  check "it makes coffee", [], %Behave.Scenario{results: results} do
     assert results.coffee != :disappointment
   end
 end


### PR DESCRIPTION
- The idea is to basically have the possibility to assign (pattern match) the scenario struct via a third argument of each step.
- Compared to an injected variable this looks clearer in my opinion because the result and data fields are captured via an argument which is there by design (just like the second argument of the steps) and can be documented as part of the doc for steps.
- Once the reader of a code understands the third argument is always the scenario object then it is easier for them to infer which fields to expect. 
- For a POC, the implementation is only done for the check step
