### PR TITLE
Add basic html reporter 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,8 @@ behave-*.tar
 # Temporary files, for example, from tests.
 /tmp/
 
+# Html test report
+behave.html
+
 .vscode
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@
 * Not a full gherkin implementation, it just gives you the ability to decompose tests into reusable named steps.
 * Separate DSLs for defining scenarios and implementing test steps.
 * Dependency Free. Use whatever assertion, mocking and testing libraries you want.
+* Create a html report.
 
 ## Usage
 
-Assuming you have a BDD stlye scenario like this:
+Assuming you have a BDD style scenario like this:
 
 ```Gherkin
 
@@ -219,3 +220,11 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
 be found at <https://hexdocs.pm/behave_bdd>.
 
+In case that you want to make Behave to create a test report, add the following to `test/test_helper.exs`:
+
+```elixir
+Behave.Formatter.Store.start() # add
+ExUnit.configure(formatters: [ExUnit.CLIFormatter, Behave.Formatter]) # add
+
+ExUnit.start()
+```

--- a/lib/behave.ex
+++ b/lib/behave.ex
@@ -3,6 +3,7 @@ defmodule Behave do
   ~Ugh baby, `Behave`!
   Simple BDD style tests for elixir.
   """
+  alias Behave.Formatter
   alias Behave.Scenario
 
   defmacro __using__(opts) do
@@ -25,6 +26,8 @@ defmodule Behave do
   end
 
   defmacro scenario(title, do: block) do
+    store_scenario(title, block)
+
     quote do
       test unquote(title) do
         var!(scenario) = Behave.Scenario.new()
@@ -100,5 +103,18 @@ defmodule Behave do
     |> String.trim()
     |> String.replace(" ", "_")
     |> String.to_atom()
+  end
+
+  defp store_scenario(title, block) do
+    steps =
+      block
+      |> elem(2)
+      |> Enum.map(fn step ->
+        {action, _, [title | params]} = step
+
+        %Formatter.Step{action: action, title: title, params: params}
+      end)
+
+    Formatter.Store.add_scenario(%Formatter.Scenario{title: title, steps: steps})
   end
 end

--- a/lib/formatter.ex
+++ b/lib/formatter.ex
@@ -1,0 +1,27 @@
+defmodule Behave.Formatter do
+  use GenServer
+
+  alias Behave.Formatter.Store
+
+  @impl true
+  def init(_opts) do
+    {:ok, nil}
+  end
+
+  @impl true
+  def handle_cast({:suite_finished, _suite}, config) do
+    Store.create_report()
+
+    {:noreply, config}
+  end
+
+  @impl true
+  def handle_cast({:test_finished, test}, config) do
+    Store.update_status(test)
+
+    {:noreply, config}
+  end
+
+  @impl true
+  def handle_cast(_, config), do: {:noreply, config}
+end

--- a/lib/formatter/html_renderer.ex
+++ b/lib/formatter/html_renderer.ex
@@ -1,0 +1,42 @@
+defmodule Behave.Formatter.HtmlRenderer do
+  def create_html_report(scenarios) do
+    File.write(report_name(), render(scenarios))
+  end
+
+  def report_name do
+    Application.get_env(:behave, :report_name, "behave.html")
+  end
+
+  defp render(scenarios) do
+    EEx.eval_string(template(), scenarios: scenarios)
+  end
+
+  defp template do
+    """
+    <head>
+      <title>Behave report</title>
+    </head>
+    <body>
+      <h1>Behave report</h1>
+      <ul>
+        <%= for scenario <- scenarios do %>
+          <li class="<%= to_string(scenario.status) %>"><%= scenario.title %> [<%= scenario.status %>]</li>
+          <ul class="<%= to_string(scenario.status) %>">
+            <%= for step <- scenario.steps do %>
+              <li><%= to_string(step.action) %> <%= step.title %> <%= step.params |> Enum.map(&inspect(&1)) |> Enum.join(", ") %></li>
+            <% end %>
+          </ul>
+        <% end %>
+      </ul>
+      <style>
+        .success {
+          color: DarkGreen;
+        }
+        .failed {
+          color: DarkRed;
+        }
+      </style>
+    </body>
+    """
+  end
+end

--- a/lib/formatter/scenario.ex
+++ b/lib/formatter/scenario.ex
@@ -1,0 +1,3 @@
+defmodule Behave.Formatter.Scenario do
+  defstruct [:title, :status, :steps]
+end

--- a/lib/formatter/step.ex
+++ b/lib/formatter/step.ex
@@ -1,0 +1,3 @@
+defmodule Behave.Formatter.Step do
+  defstruct [:action, :title, :params]
+end

--- a/lib/formatter/store.ex
+++ b/lib/formatter/store.ex
@@ -1,0 +1,81 @@
+defmodule Behave.Formatter.Store do
+  use GenServer
+
+  alias Behave.Formatter.HtmlRenderer
+
+  @impl true
+  def init(_opts) do
+    {:ok, %{}}
+  end
+
+  @impl true
+  def handle_cast({:add_scenario, scenario}, state) do
+    new_state = Map.put(state, scenario.title, scenario)
+
+    {:noreply, new_state}
+  end
+
+  @impl true
+  def handle_cast({:update_status, test}, state) do
+    state = update_state_for_test(state, test)
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call(:create_report, _from, state) do
+    state
+    |> Enum.map(&elem(&1, 1))
+    |> HtmlRenderer.create_html_report()
+
+    {:reply, :ok, state}
+  end
+
+  def add_scenario(scenario) do
+    cast(:add_scenario, scenario)
+  end
+
+  def update_status(test) do
+    cast(:update_status, test)
+  end
+
+  def create_report() do
+    call(:create_report)
+  end
+
+  def cast(action, params) do
+    GenServer.cast(__MODULE__, {action, params})
+  end
+
+  def call(action) do
+    GenServer.call(__MODULE__, action)
+  end
+
+  def start do
+    GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+  end
+
+  defp test_status(test) do
+    if test.state do
+      elem(test.state, 0)
+    else
+      :success
+    end
+  end
+
+  defp update_state_for_test(state, test) do
+    entry =
+      Enum.find(state, fn {title, _scenario} ->
+        String.contains?(to_string(test.name), title)
+      end)
+
+    if entry do
+      entry
+      |> elem(1)
+      |> Map.replace!(:status, test_status(test))
+      |> then(&Map.put(state, &1.title, &1))
+    else
+      state
+    end
+  end
+end

--- a/test/formatter/html_renderer_test.exs
+++ b/test/formatter/html_renderer_test.exs
@@ -1,0 +1,10 @@
+defmodule Formatter.HtmlRendererTest do
+  use Behave, steps: [Formatter.HtmlRendererSteps]
+  use ExUnit.Case
+
+  scenario "the formatter renders correctly the html" do
+    given "scenarios"
+    act "call create_html_report/1"
+    check "create correct html report"
+  end
+end

--- a/test/formatter/store_test.exs
+++ b/test/formatter/store_test.exs
@@ -1,0 +1,17 @@
+defmodule Formatter.StoreTest do
+  use Behave, steps: [Formatter.StoreSteps]
+  use ExUnit.Case
+
+  scenario "the store adds correctly the scenario" do
+    given "scenario"
+    act "call add_scenario"
+    check "the store state includes the scenario"
+  end
+
+  scenario "the store sets correctly the scenario status" do
+    given "scenario"
+    given "passed test"
+    act "call update_status with passed test"
+    check "the scenario has status success"
+  end
+end

--- a/test/support/formatter/html_renderer_steps.ex
+++ b/test/support/formatter/html_renderer_steps.ex
@@ -1,0 +1,71 @@
+defmodule Formatter.HtmlRendererSteps do
+  use Behave.Scenario
+  import ExUnit.Assertions
+
+  alias Behave.Formatter.HtmlRenderer
+  alias Behave.Formatter.Scenario
+  alias Behave.Formatter.Step
+
+  given "scenarios" do
+    scenarios = [
+      %Scenario{
+        title: "make coffee with different arities",
+        status: :success,
+        steps: [
+          %Step{action: :given, title: "coffee machine", params: []},
+          %Step{
+            action: :given,
+            title: "it has water and coffee",
+            params: [[amount: 500, cultivar: :kopi_luwak]]
+          },
+          %Step{
+            action: :act,
+            title: "i press the button",
+            params: []
+          },
+          %Behave.Formatter.Step{action: :check, title: "it makes coffee", params: []}
+        ]
+      },
+      %Behave.Formatter.Scenario{
+        title: "make coffee with dsl",
+        status: :failed,
+        steps: [
+          %Step{action: :given, title: "coffee machine", params: []},
+          %Step{
+            action: :given,
+            title: "it has water",
+            params: [[amount: 250]]
+          },
+          %Step{
+            action: :given,
+            title: "it has coffee",
+            params: [[cultivar: :java]]
+          },
+          %Step{
+            action: :act,
+            title: "i press the button",
+            params: []
+          },
+          %Step{action: :check, title: "it makes coffee", params: []}
+        ]
+      }
+    ]
+
+    {:scenarios, scenarios}
+  end
+
+  act "call create_html_report/1", data do
+    HtmlRenderer.create_html_report(data.scenarios)
+  end
+
+  check "create correct html report" do
+    assert {:ok, html} = File.read(HtmlRenderer.report_name())
+
+    assert html =~ "make coffee with different arities"
+    assert html =~ "it has water and coffee"
+    assert html =~ "success"
+
+    assert html =~ "make coffee with dsl"
+    assert html =~ "fail"
+  end
+end

--- a/test/support/formatter/store_steps.ex
+++ b/test/support/formatter/store_steps.ex
@@ -1,0 +1,64 @@
+defmodule Formatter.StoreSteps do
+  use Behave.Scenario
+  import ExUnit.Assertions
+
+  alias Behave.Formatter.Store
+  alias Behave.Formatter.Scenario
+
+  given "scenario" do
+    scenario = %Scenario{title: "example"}
+
+    {:scenario, scenario}
+  end
+
+  given "passed test" do
+    test = %ExUnit.Test{
+      name: :"test example",
+      case: Formatter.StoreTest,
+      module: Formatter.StoreTest,
+      state: nil,
+      time: 3,
+      tags: %{
+        async: false,
+        line: 5,
+        module: Formatter.StoreTest,
+        registered: %{},
+        file: "/home/aron/clark/behave/test/formatter/store_test.exs",
+        test: :"test example",
+        test_type: :test,
+        describe_line: nil,
+        describe: nil
+      },
+      logs: ""
+    }
+
+    {:test, test}
+  end
+
+  act "call add_scenario", data do
+    {:add_scenario_result, Store.handle_cast({:add_scenario, data.scenario}, %{})}
+  end
+
+  act "call update_status with passed test", data do
+    update_status_result  =
+      Store.handle_cast(
+        {:update_status, data.test},
+        %{ data.scenario.title => data.scenario }
+      )
+
+    {:update_status_result, update_status_result}
+  end
+
+  check "the store state includes the scenario", result, data do
+    title = data.scenario.title
+    scenario = data.scenario
+
+    assert {:noreply, %{^title => ^scenario}} = result.add_scenario_result
+  end
+
+  check "the scenario has status success", result, data do
+    title = data.scenario.title
+
+    assert {:noreply, %{^title => %{status: :success}}} = result.update_status_result
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,4 @@
+Behave.Formatter.Store.start()
+ExUnit.configure(formatters: [ExUnit.CLIFormatter, Behave.Formatter])
+
 ExUnit.start()


### PR DESCRIPTION
Implementation notes:
* The Behave.Formatter.Store saves the
  scenario description that then can be used by the formatter.
* I put most of the logic into store to avoid to duplicate
  the data into the formatter.

![Screenshot from 2024-08-28 10-34-12](https://github.com/user-attachments/assets/d4715301-3490-4577-a2f7-97e39eeb1ea5)